### PR TITLE
Probably fix Death Star display on prod

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
     <a-scene>
       <a-assets>
         <video id="player" autoplay="true">
-        <a-asset-item id="ds-obj" src="/death_star/death-star-II.obj"></a-asset-item>
-        <a-asset-item id="ds-mtl" src="/death_star/death-star-II.mtl"></a-asset-item>
+        <a-asset-item id="ds-obj" src="death_star/death-star-II.obj"></a-asset-item>
+        <a-asset-item id="ds-mtl" src="death_star/death-star-II.mtl"></a-asset-item>
       </a-assets>
       <a-entity>
         <a-animation property="rotation" dur="3000" to="0 -360 0" repeat="indefinite" easing="linear">


### PR DESCRIPTION
Prod uses /dfua-aframe as base url, not just /. Thus absolute paths from / broke Death Star display on prod. Replacing paths from root to relative ones should fix the problem.